### PR TITLE
Update to Apache Http Client 5.3 and update logback to 1.4.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 dependencies {
     implementation(
-        [group: 'org.apache.httpcomponents', name: 'httpclient', version: "4.5.14"],
+        [group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3'],
         [group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "2.15.2"],
         [group: 'org.yaml', name: 'snakeyaml', version: "2.2"],
     )
@@ -41,7 +41,7 @@ dependencies {
         // use logger only in test implementation in order to have a minimal set of dependencies in main source
         [group: 'org.slf4j', name: 'slf4j-api', version: "2.0.9"],
         [group: 'org.junit.jupiter', name: 'junit-jupiter', version: "5.10.0"],
-        [group: 'ch.qos.logback', name: 'logback-classic', version: "1.4.11"],
+        [group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.12'],
         [group: 'org.assertj', name: 'assertj-core', version: "3.24.2"]
     )
 }


### PR DESCRIPTION
Updated the Apache Http Client to version 5.3, as the last used version had some security vulnerabilities.
Required some minimal refactoring though as some of the old API was removed. Probably needs some testing.
Also updated logback from 1.4.11 to 1.4.12 while I was at it.