### PR TITLE
Feature/cloudtoolkit estimation measurement

### DIFF
--- a/src/main/java/group/msg/jpowermonitor/MeasureMethodProvider.java
+++ b/src/main/java/group/msg/jpowermonitor/MeasureMethodProvider.java
@@ -2,6 +2,7 @@ package group.msg.jpowermonitor;
 
 import group.msg.jpowermonitor.config.JPowerMonitorConfig;
 import group.msg.jpowermonitor.measurement.csv.CommaSeparatedValuesReader;
+import group.msg.jpowermonitor.measurement.est.EstimationReader;
 import group.msg.jpowermonitor.measurement.lhm.LibreHardwareMonitorReader;
 
 /**
@@ -15,6 +16,8 @@ public class MeasureMethodProvider {
             return new CommaSeparatedValuesReader(config);
         } else if ("lhm".equals(config.getMeasurement().getMethod())) {
             return new LibreHardwareMonitorReader(config);
+        } else if ("est".equals(config.getMeasurement().getMethod())) {
+            return new EstimationReader(config);
         } else {
             throw new JPowerMonitorException("Unknown measure method " + config.getMeasurement().getMethod());
         }

--- a/src/main/java/group/msg/jpowermonitor/agent/JPowerMonitorAgent.java
+++ b/src/main/java/group/msg/jpowermonitor/agent/JPowerMonitorAgent.java
@@ -4,6 +4,7 @@ import group.msg.jpowermonitor.config.DefaultConfigProvider;
 import group.msg.jpowermonitor.config.JPowerMonitorConfig;
 import group.msg.jpowermonitor.config.JavaAgent;
 import group.msg.jpowermonitor.util.Constants;
+import group.msg.jpowermonitor.util.CpuAndThreadUtils;
 
 import java.lang.instrument.Instrumentation;
 import java.lang.management.ThreadMXBean;

--- a/src/main/java/group/msg/jpowermonitor/agent/PowerStatistics.java
+++ b/src/main/java/group/msg/jpowermonitor/agent/PowerStatistics.java
@@ -4,6 +4,7 @@ import group.msg.jpowermonitor.dto.Activity;
 import group.msg.jpowermonitor.dto.DataPoint;
 import group.msg.jpowermonitor.dto.MethodActivity;
 import group.msg.jpowermonitor.dto.Quantity;
+import group.msg.jpowermonitor.util.CpuAndThreadUtils;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/group/msg/jpowermonitor/config/EstimationCfg.java
+++ b/src/main/java/group/msg/jpowermonitor/config/EstimationCfg.java
@@ -1,0 +1,12 @@
+package group.msg.jpowermonitor.config;
+
+import lombok.Data;
+
+/**
+ * Data class for estimation measurement config.
+ */
+@Data
+public class EstimationCfg {
+    private float cpuMinWatts;
+    private float cpuMaxWatts;
+}

--- a/src/main/java/group/msg/jpowermonitor/config/Measurement.java
+++ b/src/main/java/group/msg/jpowermonitor/config/Measurement.java
@@ -7,10 +7,12 @@ import lombok.Data;
  *
  * @see CsvMeasurementCfg
  * @see LibreHardwareMonitorCfg
+ * @see EstimationCfg
  */
 @Data
 public class Measurement {
     private String method;
     private CsvMeasurementCfg csv;
     private LibreHardwareMonitorCfg lhm;
+    private EstimationCfg est;
 }

--- a/src/main/java/group/msg/jpowermonitor/measurement/AbstractCommonReader.java
+++ b/src/main/java/group/msg/jpowermonitor/measurement/AbstractCommonReader.java
@@ -1,0 +1,78 @@
+package group.msg.jpowermonitor.measurement;
+
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import group.msg.jpowermonitor.JPowerMonitorException;
+import group.msg.jpowermonitor.MeasureMethod;
+import group.msg.jpowermonitor.config.JPowerMonitorConfig;
+import group.msg.jpowermonitor.dto.DataPoint;
+
+/**
+ * Implementation of shared methods equal for all measure methods.
+ *
+ * @see MeasureMethod
+ */
+public abstract class AbstractCommonReader implements MeasureMethod {
+
+    protected final JPowerMonitorConfig config;
+
+    public AbstractCommonReader(JPowerMonitorConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public abstract @NotNull List<DataPoint> measure() throws JPowerMonitorException;
+
+    @Override
+    public abstract @NotNull DataPoint measureFirstConfiguredPath() throws JPowerMonitorException;
+
+    @Override
+    public abstract @NotNull List<String> configuredSensors();
+
+    @Override
+    public abstract @NotNull Map<String, BigDecimal> defaultEnergyInIdleModeForMeasuredSensors();
+
+    @Override
+    public int getSamplingInterval() {
+        return config.getSamplingIntervalInMs();
+    }
+
+    @Override
+    public int initCycles() {
+        return config.getInitCycles();
+    }
+
+    @Override
+    public int getSamplingIntervalForInit() {
+        return config.getInitCycles();
+    }
+
+    @Override
+    public int getCalmDownIntervalInMs() {
+        return config.getCalmDownIntervalInMs();
+    }
+
+    @Override
+    public @Nullable Path getPathToResultCsv() {
+        return config.getCsvRecording().getResultCsv() != null ? Paths.get(
+                config.getCsvRecording().getResultCsv()) : null;
+    }
+
+    @Override
+    public @Nullable Path getPathToMeasurementCsv() {
+        return config.getCsvRecording().getMeasurementCsv() != null ? Paths.get(
+                config.getCsvRecording().getMeasurementCsv()) : null;
+    }
+
+    @Override
+    public @NotNull BigDecimal getPercentageOfSamplesAtBeginningToDiscard() {
+        return config.getPercentageOfSamplesAtBeginningToDiscard();
+    }
+}

--- a/src/main/java/group/msg/jpowermonitor/measurement/csv/CommaSeparatedValuesReader.java
+++ b/src/main/java/group/msg/jpowermonitor/measurement/csv/CommaSeparatedValuesReader.java
@@ -7,9 +7,9 @@ import group.msg.jpowermonitor.config.CsvColumn;
 import group.msg.jpowermonitor.config.CsvMeasurementCfg;
 import group.msg.jpowermonitor.config.JPowerMonitorConfig;
 import group.msg.jpowermonitor.dto.DataPoint;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import group.msg.jpowermonitor.measurement.AbstractCommonReader;
 
+import org.jetbrains.annotations.NotNull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -35,12 +35,12 @@ import java.util.stream.Stream;
  * Implementation of the Comma separated value measure method. E.g. for HWiNFO or other CSV generating tools.
  *
  * @see MeasureMethod
+ * @see AbstractCommonReader
  */
-public class CommaSeparatedValuesReader implements MeasureMethod {
-    private final JPowerMonitorConfig config;
+public class CommaSeparatedValuesReader extends AbstractCommonReader {
 
     public CommaSeparatedValuesReader(JPowerMonitorConfig config) {
-        this.config = config;
+        super(config);
         initCsvConfig(config);
     }
 
@@ -215,42 +215,5 @@ public class CommaSeparatedValuesReader implements MeasureMethod {
             .filter(x -> x.getEnergyInIdleMode() != null)
             .forEach(c -> energyInIdleModeForMeasuredSensors.put(c.getName(), c.getEnergyInIdleMode()));
         return energyInIdleModeForMeasuredSensors;
-    }
-
-    @Override
-    public int getSamplingInterval() {
-        return config.getSamplingIntervalInMs();
-    }
-
-    @Override
-    public int initCycles() {
-        return config.getInitCycles();
-    }
-
-    @Override
-    public int getSamplingIntervalForInit() {
-        return config.getSamplingIntervalForInitInMs();
-    }
-
-    @Override
-    public int getCalmDownIntervalInMs() {
-        return config.getCalmDownIntervalInMs();
-    }
-
-    @Override
-    public @Nullable Path getPathToResultCsv() {
-        return config.getCsvRecording().getResultCsv() != null ? Paths.get(
-            config.getCsvRecording().getResultCsv()) : null;
-    }
-
-    @Override
-    public @Nullable Path getPathToMeasurementCsv() {
-        return config.getCsvRecording().getMeasurementCsv() != null ? Paths.get(
-            config.getCsvRecording().getMeasurementCsv()) : null;
-    }
-
-    @Override
-    public @NotNull BigDecimal getPercentageOfSamplesAtBeginningToDiscard() {
-        return config.getPercentageOfSamplesAtBeginningToDiscard();
     }
 }

--- a/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
+++ b/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
@@ -1,0 +1,103 @@
+package group.msg.jpowermonitor.measurement.est;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import group.msg.jpowermonitor.JPowerMonitorException;
+import group.msg.jpowermonitor.MeasureMethod;
+import group.msg.jpowermonitor.agent.Unit;
+import group.msg.jpowermonitor.config.EstimationCfg;
+import group.msg.jpowermonitor.config.JPowerMonitorConfig;
+import group.msg.jpowermonitor.dto.DataPoint;
+
+/**
+ * Implementation of the Estimation (compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours) measure method.
+ *
+ * @see MeasureMethod
+ */
+public class EstimationReader implements MeasureMethod {
+
+    private static final double EST_CPU_LOAD_FALLBACK = 0.5;
+    private static final String ESTIMATED_CPU_WATTS = "Estimated CPU Watts";
+
+    private final JPowerMonitorConfig config;
+    private final EstimationCfg estCfg;
+    private final OperatingSystemMXBean osBean;
+
+    public EstimationReader(JPowerMonitorConfig config) {
+        this.config = config;
+        Objects.requireNonNull(config.getMeasurement().getEst(), "Estimation config must be set!");
+        this.estCfg = config.getMeasurement().getEst();
+        osBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
+    }
+
+    @Override
+    public @NotNull List<DataPoint> measure() throws JPowerMonitorException {
+        return List.of(measureFirstConfiguredPath());
+    }
+
+    @Override
+    public @NotNull DataPoint measureFirstConfiguredPath() throws JPowerMonitorException {
+        // Compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours
+        BigDecimal value = BigDecimal.valueOf(estCfg.getCpuMinWatts() + (osBean != null ? osBean.getSystemLoadAverage() : EST_CPU_LOAD_FALLBACK * (estCfg.getCpuMaxWatts() - estCfg.getCpuMinWatts()))); 
+        return new DataPoint(ESTIMATED_CPU_WATTS, value, Unit.WATT, LocalDateTime.now(), Thread.currentThread().getName());
+    }
+
+    @Override
+    public @NotNull List<String> configuredSensors() {
+        return List.of(ESTIMATED_CPU_WATTS);
+    }
+
+    @Override
+    public @NotNull Map<String, BigDecimal> defaultEnergyInIdleModeForMeasuredSensors() {
+        return Map.of(ESTIMATED_CPU_WATTS, BigDecimal.valueOf(estCfg.getCpuMinWatts()));
+    }
+
+    @Override
+    public int getSamplingInterval() {
+        return config.getSamplingIntervalInMs();
+    }
+
+    @Override
+    public int initCycles() {
+        return config.getInitCycles();
+    }
+
+    @Override
+    public int getSamplingIntervalForInit() {
+        return config.getInitCycles();
+    }
+
+    @Override
+    public int getCalmDownIntervalInMs() {
+        return config.getCalmDownIntervalInMs();
+    }
+
+    @Override
+    public @Nullable Path getPathToResultCsv() {
+        return config.getCsvRecording().getResultCsv() != null ? Paths.get(
+            config.getCsvRecording().getResultCsv()) : null;
+    }
+
+    @Override
+    public @Nullable Path getPathToMeasurementCsv() {
+        return config.getCsvRecording().getMeasurementCsv() != null ? Paths.get(
+            config.getCsvRecording().getMeasurementCsv()) : null;
+    }
+
+    @Override
+    public @NotNull BigDecimal getPercentageOfSamplesAtBeginningToDiscard() {
+        return config.getPercentageOfSamplesAtBeginningToDiscard();
+    }
+
+}

--- a/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
+++ b/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
@@ -49,7 +49,9 @@ public class EstimationReader implements MeasureMethod {
     @Override
     public @NotNull DataPoint measureFirstConfiguredPath() throws JPowerMonitorException {
         // Compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours
-        BigDecimal value = BigDecimal.valueOf(estCfg.getCpuMinWatts() + (osBean != null ? osBean.getSystemLoadAverage() : EST_CPU_LOAD_FALLBACK * (estCfg.getCpuMaxWatts() - estCfg.getCpuMinWatts()))); 
+        final double cpuLoad = osBean != null && osBean.getSystemLoadAverage() > 0 ? osBean.getSystemLoadAverage() : EST_CPU_LOAD_FALLBACK;
+        BigDecimal value = BigDecimal.valueOf(estCfg.getCpuMinWatts() + (cpuLoad * (estCfg.getCpuMaxWatts() - estCfg.getCpuMinWatts())));
+        System.out.println("cpuLoad: " + cpuLoad + ", value: " + value + "W");
         return new DataPoint(ESTIMATED_CPU_WATTS, value, Unit.WATT, LocalDateTime.now(), Thread.currentThread().getName());
     }
 

--- a/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
+++ b/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
@@ -1,38 +1,35 @@
 package group.msg.jpowermonitor.measurement.est;
 
 import java.math.BigDecimal;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import group.msg.jpowermonitor.JPowerMonitorException;
 import group.msg.jpowermonitor.MeasureMethod;
 import group.msg.jpowermonitor.agent.Unit;
 import group.msg.jpowermonitor.config.EstimationCfg;
 import group.msg.jpowermonitor.config.JPowerMonitorConfig;
 import group.msg.jpowermonitor.dto.DataPoint;
+import group.msg.jpowermonitor.measurement.AbstractCommonReader;
 import group.msg.jpowermonitor.util.CpuAndThreadUtils;
 
 /**
  * Implementation of the Estimation (compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours) measure method.
  *
  * @see MeasureMethod
+ * @see AbstractCommonReader
  */
-public class EstimationReader implements MeasureMethod {
+public class EstimationReader extends AbstractCommonReader {
 
     private static final String ESTIMATED_CPU_WATTS = "Estimated CPU Watts";
 
-    private final JPowerMonitorConfig config;
     private final EstimationCfg estCfg;
 
     public EstimationReader(JPowerMonitorConfig config) {
-        this.config = config;
+        super(config);
         Objects.requireNonNull(config.getMeasurement().getEst(), "Estimation config must be set!");
         this.estCfg = config.getMeasurement().getEst();
     }
@@ -60,42 +57,4 @@ public class EstimationReader implements MeasureMethod {
     public @NotNull Map<String, BigDecimal> defaultEnergyInIdleModeForMeasuredSensors() {
         return Map.of(ESTIMATED_CPU_WATTS, BigDecimal.valueOf(estCfg.getCpuMinWatts()));
     }
-
-    @Override
-    public int getSamplingInterval() {
-        return config.getSamplingIntervalInMs();
-    }
-
-    @Override
-    public int initCycles() {
-        return config.getInitCycles();
-    }
-
-    @Override
-    public int getSamplingIntervalForInit() {
-        return config.getInitCycles();
-    }
-
-    @Override
-    public int getCalmDownIntervalInMs() {
-        return config.getCalmDownIntervalInMs();
-    }
-
-    @Override
-    public @Nullable Path getPathToResultCsv() {
-        return config.getCsvRecording().getResultCsv() != null ? Paths.get(
-            config.getCsvRecording().getResultCsv()) : null;
-    }
-
-    @Override
-    public @Nullable Path getPathToMeasurementCsv() {
-        return config.getCsvRecording().getMeasurementCsv() != null ? Paths.get(
-            config.getCsvRecording().getMeasurementCsv()) : null;
-    }
-
-    @Override
-    public @NotNull BigDecimal getPercentageOfSamplesAtBeginningToDiscard() {
-        return config.getPercentageOfSamplesAtBeginningToDiscard();
-    }
-
 }

--- a/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
+++ b/src/main/java/group/msg/jpowermonitor/measurement/est/EstimationReader.java
@@ -1,7 +1,5 @@
 package group.msg.jpowermonitor.measurement.est;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,6 +17,7 @@ import group.msg.jpowermonitor.agent.Unit;
 import group.msg.jpowermonitor.config.EstimationCfg;
 import group.msg.jpowermonitor.config.JPowerMonitorConfig;
 import group.msg.jpowermonitor.dto.DataPoint;
+import group.msg.jpowermonitor.util.CpuAndThreadUtils;
 
 /**
  * Implementation of the Estimation (compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours) measure method.
@@ -27,18 +26,15 @@ import group.msg.jpowermonitor.dto.DataPoint;
  */
 public class EstimationReader implements MeasureMethod {
 
-    private static final double EST_CPU_LOAD_FALLBACK = 0.5;
     private static final String ESTIMATED_CPU_WATTS = "Estimated CPU Watts";
 
     private final JPowerMonitorConfig config;
     private final EstimationCfg estCfg;
-    private final OperatingSystemMXBean osBean;
 
     public EstimationReader(JPowerMonitorConfig config) {
         this.config = config;
         Objects.requireNonNull(config.getMeasurement().getEst(), "Estimation config must be set!");
         this.estCfg = config.getMeasurement().getEst();
-        osBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
     }
 
     @Override
@@ -49,9 +45,9 @@ public class EstimationReader implements MeasureMethod {
     @Override
     public @NotNull DataPoint measureFirstConfiguredPath() throws JPowerMonitorException {
         // Compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours
-        final double cpuLoad = osBean != null && osBean.getSystemLoadAverage() > 0 ? osBean.getSystemLoadAverage() : EST_CPU_LOAD_FALLBACK;
-        BigDecimal value = BigDecimal.valueOf(estCfg.getCpuMinWatts() + (cpuLoad * (estCfg.getCpuMaxWatts() - estCfg.getCpuMinWatts())));
-        System.out.println("cpuLoad: " + cpuLoad + ", value: " + value + "W");
+        final double cpuUsage = CpuAndThreadUtils.getCpuUsage();
+        BigDecimal value = BigDecimal.valueOf(estCfg.getCpuMinWatts() + (cpuUsage * (estCfg.getCpuMaxWatts() - estCfg.getCpuMinWatts())));
+        //System.out.println("cpuUsage: " + cpuUsage + ", value: " + value + "W"); // DEBUG
         return new DataPoint(ESTIMATED_CPU_WATTS, value, Unit.WATT, LocalDateTime.now(), Thread.currentThread().getName());
     }
 

--- a/src/main/java/group/msg/jpowermonitor/measurement/lhm/LibreHardwareMonitorReader.java
+++ b/src/main/java/group/msg/jpowermonitor/measurement/lhm/LibreHardwareMonitorReader.java
@@ -8,18 +8,15 @@ import group.msg.jpowermonitor.config.JPowerMonitorConfig;
 import group.msg.jpowermonitor.config.LibreHardwareMonitorCfg;
 import group.msg.jpowermonitor.config.PathElement;
 import group.msg.jpowermonitor.dto.DataPoint;
+import group.msg.jpowermonitor.measurement.AbstractCommonReader;
 import lombok.NonNull;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,14 +29,14 @@ import java.util.stream.Collectors;
  * Implementation of the Libre Hardware Monitor measure method.
  *
  * @see MeasureMethod
+ * @see AbstractCommonReader
  */
-public class LibreHardwareMonitorReader implements MeasureMethod {
+public class LibreHardwareMonitorReader extends AbstractCommonReader {
     HttpClient client;
-    JPowerMonitorConfig config;
     LibreHardwareMonitorCfg lhmConfig;
 
     public LibreHardwareMonitorReader(JPowerMonitorConfig config) {
-        this.config = config;
+        super(config);
         Objects.requireNonNull(config.getMeasurement().getLhm(), "Libre Hardware Monitor config must be set!");
         this.lhmConfig = config.getMeasurement().getLhm();
         this.client = HttpClientBuilder.create().build();
@@ -112,41 +109,6 @@ public class LibreHardwareMonitorReader implements MeasureMethod {
             .filter(x -> x.getEnergyInIdleMode() != null)
             .forEach(p -> energyInIdleModeForMeasuredSensors.put(String.join("->", p.getPath()), p.getEnergyInIdleMode()));
         return energyInIdleModeForMeasuredSensors;
-    }
-
-    @Override
-    public int getSamplingInterval() {
-        return config.getSamplingIntervalInMs();
-    }
-
-    @Override
-    public int initCycles() {
-        return config.getInitCycles();
-    }
-
-    @Override
-    public int getSamplingIntervalForInit() {
-        return config.getSamplingIntervalForInitInMs();
-    }
-
-    @Override
-    public int getCalmDownIntervalInMs() {
-        return config.getCalmDownIntervalInMs();
-    }
-
-    @Override
-    public @Nullable Path getPathToResultCsv() {
-        return config.getCsvRecording().getResultCsv() != null ? Paths.get(config.getCsvRecording().getResultCsv()) : null;
-    }
-
-    @Override
-    public @Nullable Path getPathToMeasurementCsv() {
-        return config.getCsvRecording().getMeasurementCsv() != null ? Paths.get(config.getCsvRecording().getMeasurementCsv()) : null;
-    }
-
-    @Override
-    public @NotNull BigDecimal getPercentageOfSamplesAtBeginningToDiscard() {
-        return config.getPercentageOfSamplesAtBeginningToDiscard();
     }
 
     private DataElem findElement(DataElem root, Object[] path) {

--- a/src/main/java/group/msg/jpowermonitor/util/CpuAndThreadUtils.java
+++ b/src/main/java/group/msg/jpowermonitor/util/CpuAndThreadUtils.java
@@ -20,6 +20,7 @@ import static group.msg.jpowermonitor.util.Constants.ONE_HUNDRED;
  */
 public class CpuAndThreadUtils {
 
+    private static final double EST_CPU_USAGE_FALLBACK = 0.5;
     private static ThreadMXBean threadMXBean;
 
     @NotNull
@@ -43,7 +44,7 @@ public class CpuAndThreadUtils {
     public static long getTotalApplicationCpuTimeAndCalculateCpuTimePerApplicationThread(ThreadMXBean threadMxBean, Map<String, Long> cpuTimePerApplicationThread, Set<Thread> applicationThreads) {
         long totalApplicationCpuTime = 0;
         for (Thread t : applicationThreads) {
-            long applicationThreadCpuTime = threadMxBean.getThreadCpuTime(t.getId());
+            long applicationThreadCpuTime = threadMxBean.getThreadCpuTime(t.threadId());
 
             // If thread already monitored, then calculate CPU time since last time
             if (cpuTimePerApplicationThread.containsKey(t.getName())) {
@@ -66,5 +67,45 @@ public class CpuAndThreadUtils {
             powerPerApplicationThread.put(entry.getKey(), applicationThreadPower);
         }
         return powerPerApplicationThread;
+    }
+
+    @NotNull
+    public static double getCpuUsage() {
+        double cpuUsage = EST_CPU_USAGE_FALLBACK; // Compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours
+        long[] ids = CpuAndThreadUtils.initializeAndGetThreadMxBeanOrFailAndQuitApplication().getAllThreadIds();
+        
+        // Startzeit CPU-Zeit
+        long startTime = System.nanoTime();
+        long startCpuTime = 0;
+        for (long id : ids) {
+            startCpuTime += CpuAndThreadUtils.initializeAndGetThreadMxBeanOrFailAndQuitApplication().getThreadCpuTime(id);
+        }
+        
+        // Wartezeit
+        try {
+            // 100 Millisekunden
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } 
+        
+        // Endzeit CPU-Zeit
+        long endTime = System.nanoTime();
+        long endCpuTime = 0;
+        for (long id : ids) {
+            endCpuTime += CpuAndThreadUtils.initializeAndGetThreadMxBeanOrFailAndQuitApplication().getThreadCpuTime(id);
+        }
+        
+        // Berechnung der CPU-Auslastung
+        long elapsedCpu = endCpuTime - startCpuTime;
+        long elapsedTime = endTime - startTime;
+        cpuUsage = (double) elapsedCpu / elapsedTime;
+
+        if (cpuUsage <= 0) { // Fallback to 0.5 if CPU usage is negative or zero
+            cpuUsage = EST_CPU_USAGE_FALLBACK;
+        } else if (cpuUsage > 1) { // Fallback to 1 if CPU usage is greater than 1 - more than 100% is not possible ;)
+            cpuUsage = 1;
+        }
+        return cpuUsage;
     }
 }

--- a/src/main/java/group/msg/jpowermonitor/util/CpuAndThreadUtils.java
+++ b/src/main/java/group/msg/jpowermonitor/util/CpuAndThreadUtils.java
@@ -1,4 +1,4 @@
-package group.msg.jpowermonitor.agent;
+package group.msg.jpowermonitor.util;
 
 import group.msg.jpowermonitor.dto.DataPoint;
 import org.jetbrains.annotations.NotNull;
@@ -19,23 +19,28 @@ import static group.msg.jpowermonitor.util.Constants.ONE_HUNDRED;
  * @author deinerj
  */
 public class CpuAndThreadUtils {
-    @NotNull
-    static ThreadMXBean initializeAndGetThreadMxBeanOrFailAndQuitApplication() {
-        ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
-        // Check if CPU Time measurement is supported by the JVM. Quit otherwise
-        if (!threadMxBean.isThreadCpuTimeSupported()) {
-            System.err.println("Thread CPU Time is not supported in this JVM, unable to measure energy consumption.");
-            System.exit(1);
-        }
 
-        // Enable CPU Time measurement if it is disabled
-        if (!threadMxBean.isThreadCpuTimeEnabled()) {
-            threadMxBean.setThreadCpuTimeEnabled(true);
+    private static ThreadMXBean threadMXBean;
+
+    @NotNull
+    public static ThreadMXBean initializeAndGetThreadMxBeanOrFailAndQuitApplication() {
+        if (threadMXBean == null)  {
+            threadMXBean = ManagementFactory.getThreadMXBean();
+            // Check if CPU Time measurement is supported by the JVM. Quit otherwise
+            if (!threadMXBean.isThreadCpuTimeSupported()) {
+                System.err.println("Thread CPU Time is not supported in this JVM, unable to measure energy consumption.");
+                System.exit(1);
+            }
+    
+            // Enable CPU Time measurement if it is disabled
+            if (!threadMXBean.isThreadCpuTimeEnabled()) {
+                threadMXBean.setThreadCpuTimeEnabled(true);
+            }
         }
-        return threadMxBean;
+        return threadMXBean;
     }
 
-    static long getTotalApplicationCpuTimeAndCalculateCpuTimePerApplicationThread(ThreadMXBean threadMxBean, Map<String, Long> cpuTimePerApplicationThread, Set<Thread> applicationThreads) {
+    public static long getTotalApplicationCpuTimeAndCalculateCpuTimePerApplicationThread(ThreadMXBean threadMxBean, Map<String, Long> cpuTimePerApplicationThread, Set<Thread> applicationThreads) {
         long totalApplicationCpuTime = 0;
         for (Thread t : applicationThreads) {
             long applicationThreadCpuTime = threadMxBean.getThreadCpuTime(t.getId());
@@ -52,7 +57,7 @@ public class CpuAndThreadUtils {
     }
 
     @NotNull
-    static Map<String, BigDecimal> calculatePowerPerApplicationThread(Map<String, Long> cpuTimePerApplicationThread, DataPoint currentPower, long totalApplicationCpuTime) {
+    public static Map<String, BigDecimal> calculatePowerPerApplicationThread(Map<String, Long> cpuTimePerApplicationThread, DataPoint currentPower, long totalApplicationCpuTime) {
         Map<String, BigDecimal> powerPerApplicationThread = new HashMap<>();
         for (Map.Entry<String, Long> entry : cpuTimePerApplicationThread.entrySet()) {
             BigDecimal percentageCpuTimePerApplicationThread =

--- a/src/main/java/group/msg/jpowermonitor/util/CpuAndThreadUtils.java
+++ b/src/main/java/group/msg/jpowermonitor/util/CpuAndThreadUtils.java
@@ -74,34 +74,33 @@ public class CpuAndThreadUtils {
         double cpuUsage = EST_CPU_USAGE_FALLBACK; // Compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours
         long[] ids = CpuAndThreadUtils.initializeAndGetThreadMxBeanOrFailAndQuitApplication().getAllThreadIds();
         
-        // Startzeit CPU-Zeit
+        // Init measurement start time and CPU time
         long startTime = System.nanoTime();
         long startCpuTime = 0;
         for (long id : ids) {
             startCpuTime += CpuAndThreadUtils.initializeAndGetThreadMxBeanOrFailAndQuitApplication().getThreadCpuTime(id);
         }
         
-        // Wartezeit
+        // Wait for 100ms
         try {
-            // 100 Millisekunden
             Thread.sleep(100);
         } catch (InterruptedException e) {
             e.printStackTrace();
         } 
         
-        // Endzeit CPU-Zeit
+        // End measurement and add CPU time of all threads
         long endTime = System.nanoTime();
         long endCpuTime = 0;
         for (long id : ids) {
             endCpuTime += CpuAndThreadUtils.initializeAndGetThreadMxBeanOrFailAndQuitApplication().getThreadCpuTime(id);
         }
         
-        // Berechnung der CPU-Auslastung
+        // Calculate approximated CPU usage in the last 100ms
         long elapsedCpu = endCpuTime - startCpuTime;
         long elapsedTime = endTime - startTime;
         cpuUsage = (double) elapsedCpu / elapsedTime;
 
-        if (cpuUsage <= 0) { // Fallback to 0.5 if CPU usage is negative or zero
+        if (cpuUsage <= 0) { // Fallback to 0.5 (50%) if CPU usage is negative or zero
             cpuUsage = EST_CPU_USAGE_FALLBACK;
         } else if (cpuUsage > 1) { // Fallback to 1 if CPU usage is greater than 1 - more than 100% is not possible ;)
             cpuUsage = 1;

--- a/src/main/resources/jpowermonitor-template.yaml
+++ b/src/main/resources/jpowermonitor-template.yaml
@@ -16,7 +16,7 @@ samplingIntervalInMs: 300
 carbonDioxideEmissionFactor: 498
 
 measurement:
-  # Specify which measurement method to use. Possible values: lhm, csv
+  # Specify which measurement method to use. Possible values: lhm, csv, est
   method: 'lhm'
   # Configuration for reading from csv file. E.g. output from HWInfo
   csv:
@@ -42,6 +42,10 @@ measurement:
       #- { path: [ 'MSGN13205', 'Intel Core i7-9850H', 'Powers', 'CPU Cores' ], energyInIdleMode: 9.5 }
       #- { path: [ 'MSGN13205', 'Intel Core i7-9850H', 'Temperatures', 'CPU Core #1' ] } # no energyInIdleMode for temperatures...
       #- { path: [ 'MSGN16749', '11th Gen Intel Core i7-11850H', 'Powers', 'CPU Package' ], energyInIdleMode: }
+  est:
+    # Compare https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours - defaults are the average values from AWS
+    cpuMinWatts: 0.74
+    cpuMaxWatts: 3.5
 
 # ------------------------------------------------
 # Recording settings: (recordings have no effect on measured power consumption, as this is done after the test)

--- a/src/test/java/com/msg/myapplication/EndlessLoopTest.java
+++ b/src/test/java/com/msg/myapplication/EndlessLoopTest.java
@@ -4,7 +4,6 @@ import group.msg.jpowermonitor.dto.SensorValue;
 import group.msg.jpowermonitor.dto.SensorValues;
 import group.msg.jpowermonitor.junit.JPowerMonitorExtension;
 import group.msg.jpowermonitor.util.StressCpuExample;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +15,6 @@ import static group.msg.jpowermonitor.agent.Unit.WATT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith({JPowerMonitorExtension.class})
-@Slf4j
 public class EndlessLoopTest {
     @SensorValues
     private List<SensorValue> valueList;

--- a/src/test/java/group/msg/jpowermonitor/junit/ResultsWriterTest.java
+++ b/src/test/java/group/msg/jpowermonitor/junit/ResultsWriterTest.java
@@ -21,13 +21,13 @@ class ResultsWriterTest {
 
     static Stream<Arguments> l10nTestConstructorValues() {
         return Stream.of(
-            arguments(new Locale("en", "US"),
+            arguments(new Locale.Builder().setLanguage("en").setRegion("US").build(),
                 "Time,Name,Sensor,Value,Unit,Baseload,Unit,Value+Baseload,Unit,Energy(Value),Unit,Energy(Value+Baseload),Unit,CO2 Value,Unit",
                 "Time,Name,Sensor,Value,Unit"),
-            arguments(new Locale("de", "DE"),
+            arguments(new Locale.Builder().setLanguage("de").setRegion("DE").build(),
                 "Uhrzeit;Name;Sensor;Wert;Einheit;Grundlast;Einheit;Wert+Grundlast;Einheit;Energie(Wert);Einheit;Energie(Wert+Grundlast);Einheit;CO2 Wert;Einheit",
                 "Uhrzeit;Name;Sensor;Wert;Einheit"),
-            arguments(new Locale("fr", "FR"),
+            arguments(new Locale.Builder().setLanguage("fr").setRegion("FR").build(),
                 "Heure,Nom,D\u00E9tecteur,Valeur,Unit\u00E9,Grundlast,Unit\u00E9,Valeur+charge de base,Unit\u00E9,Energie(valeur),Unit\u00E9,Energie(valeur+charge de base),Unit\u00E9,CO2 Valeur,Unit\u00E9",
                 "Heure,Nom,D\u00E9tecteur,Valeur,Unit\u00E9")
         );


### PR DESCRIPTION
1st draft implementation of the planned "jPowerMonitor Cloud-Toolkit" function "energy usage estimation by approximate CPU usage in cloud/virtualized environments"

User may configure cpuMinWatts and cpuMaxWatts, based on the CPU usage a wattage estimation is done like described here: 
https://www.cloudcarbonfootprint.org/docs/methodology/#energy-estimate-watt-hours

Some tests on my local machine delivered pretty good results where estimations running the "StressCpuExample" were in 5% - 15% range given appropriate min-maxCpuWatts in comparison to measurement with LibreHardwareMonitor