### PR TITLE
Migrate to JUnit 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - upgrade com.fasterxml.jackson.datatype.jackson-datatype-jsr310 to 2.20.0
     - upgrade org.apache.httpcomponents.client5:httpclient5 to 5.5.1
     - upgrade org.jetbrains:annotations to 26.0.2-1
-    - upgrade org.junit.jupiter:junit-jupiter to 5.13.4
+    - upgrade org.junit.jupiter:junit-jupiter to 6.0.0 (JUnit 6 migration)
     - upgrade org.assertj:assertj-core to 3.27.6
     - upgrade org.yaml:snakeyaml to 2.5
     - upgrade gradle to 9.1.0
     - upgrade com.gradleup.shadow plugin to 9.2.2 (for Gradle 9.x compatibility)
     - Require JDK 17 now, as many libraries do require JDK 17 or higher
+    - Migrated to JUnit 6.0.0 (released September 30, 2025)
+    - Note: Projects using jPowerMonitor can continue to use JUnit 5.x due to backward compatibility of the JUnit Jupiter Extension API
 
 ## 2025-05-12 - release 1.2.2
 - dependency updates:

--- a/build.gradle
+++ b/build.gradle
@@ -55,13 +55,13 @@ dependencies {
     )
     compileOnly(
         'org.jetbrains:annotations:26.0.2-1',
-        'org.junit.jupiter:junit-jupiter:5.13.4'
+        'org.junit.jupiter:junit-jupiter:6.0.0'
     )
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation(
         // use logger only in test implementation in order to have a minimal set of dependencies in main source
         'org.slf4j:slf4j-simple:2.0.17',
-        'org.junit.jupiter:junit-jupiter:5.13.4',
+        'org.junit.jupiter:junit-jupiter:6.0.0',
         'org.assertj:assertj-core:3.27.6'
     )
 }


### PR DESCRIPTION
- Upgrade org.junit.jupiter:junit-jupiter from 5.13.4 to 6.0.0

- Update CHANGELOG.md with migration notes and backward compatibility information

- Add note that projects using jPowerMonitor can continue to use JUnit 5.x

- JUnit Jupiter Extension API remains compatible with JUnit 5.x